### PR TITLE
Check Sync Committee 

### DIFF
--- a/helper/check_sync_committee.sh
+++ b/helper/check_sync_committee.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Reference link https://www.coincashew.com/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-ii-maintenance/checking-my-eth-validators-sync-committee-duties
+# this script allow you to check if your nodes are scheduled to be part of a sync committee 
+# Run using: ./check_sync_committee.sh <validator index number(s)>
+# Original credit to https://www.reddit.com/user/2038/
+# Modified by Jexxa to have pulsechain timings
+
+BEACON_NODE="http://localhost:5052"
+VALIDATOR_LIST=$(echo "$@" | tr ' ' '|')
+
+epoch_to_time(){
+    expr 1683785555 + \( $1 \* 320 \)
+    }
+
+time_to_epoch(){
+    expr \( $1 - 1683785555 \) / 320
+    }
+
+get_committee(){
+    URLSTEM="${BEACON_NODE}/eth/v1/beacon/states/finalized"
+    curl -X GET "${URLSTEM}/sync_committees?epoch=$1" 2> /dev/null \
+    | sed -e 's/["]/''/g' | cut -d'[' -f2 | cut -d']' -f1 | tr ',' '\n'
+    }
+
+search_committee(){
+    get_committee $2 | grep -Ex $VALIDATOR_LIST \
+    | awk -v c=$1 '{print "validator:", $1, "found in", c, "sync committee"}'
+    }
+
+display_epoch(){
+    echo "epoch: $1 : $(date -d@$(epoch_to_time $1)) <-- $2"
+    }
+
+CURR_EPOCH=$(time_to_epoch $(date +%s))
+CURR_START_EPOCH=`expr \( $CURR_EPOCH / 256 \) \* 256`
+NEXT_START_EPOCH=`expr $CURR_START_EPOCH + 256`
+NEXTB1_START_EPOCH=`expr $NEXT_START_EPOCH + 256`
+
+echo
+display_epoch $CURR_START_EPOCH   "current sync committee start"
+display_epoch $CURR_EPOCH         "now"
+display_epoch $NEXT_START_EPOCH   "next sync committee start"
+display_epoch $NEXTB1_START_EPOCH "next-but-one sync committee start"
+echo
+
+if [ "$#" -gt 0 ]
+then
+    search_committee "current" $CURR_EPOCH
+    search_committee "next"    $NEXT_START_EPOCH
+fi


### PR DESCRIPTION
This script allows operators to check if their validators are scheduled to be, or are part of a sync committee. This can be useful for planning downtime.