### PR TITLE
fix prometheus path

### DIFF
--- a/setup_monitoring.sh
+++ b/setup_monitoring.sh
@@ -187,7 +187,7 @@ echo ""
 # Define Docker commands as variables
 PROMETHEUS_CMD="sudo -u prometheus docker run -dt --name prometheus --restart=always \\
   --net='host' \\
-  -v ${config_location}/prometheus.yml:/etc/prometheus/prometheus.yml \\
+  -v ${config_location}/prometheus.yml:/prometheus/prometheus.yml \\
   -v ${config_location}/prometheus:/prometheus-data \\
   prom/prometheus
   


### PR DESCRIPTION
The path seems to be incorrect when setting up the inital start script. 

This causes the prometheus container to get stuck at "restarting" as it can't find the prometheus.yml file.
